### PR TITLE
Upgrade to SDK 6.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ SPARK_CONTAINER := ${DOCKER_PREGISTRY_URL}/${DOCKER_IMAGE}:${TAG}
 all: clean build create-app-image deploy-skill
 
 create-app-image:
-	docker build --build-arg base_img=c12e/spark-template:profile-jar-base-6.3.0-M.2.5 -t ${DOCKER_IMAGE}:${TAG} -f ./main-app/build/resources/main/Dockerfile ./main-app/build
+	docker build --build-arg base_img=c12e/spark-template:profile-jar-base-6.3.1 -t ${DOCKER_IMAGE}:${TAG} -f ./main-app/build/resources/main/Dockerfile ./main-app/build
 
 # Build the Application
 build:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -89,7 +89,7 @@ subprojects {
 		resolutionStrategy {
 			eachDependency {
 				when (requested.group) {
-					"com.c12e.cortex.profiles" -> useVersion("6.3.0-M.2.5")
+					"com.c12e.cortex.profiles" -> useVersion("6.3.1")
 				}
 			}
 		}


### PR DESCRIPTION
Shouldn't be merged to main until release. This is just getting the examples dependent on the new version of the SDK