### PR TITLE
FAB-5808 pass project from skill request down to spark driver

### DIFF
--- a/main-app/src/main/resources/python/submit_job.py
+++ b/main-app/src/main/resources/python/submit_job.py
@@ -149,6 +149,12 @@ if __name__ == '__main__':
                              "spark.kubernetes.executor.podTemplateContainerName": "fabric-action"}
             spark_config.get("pyspark", {}).get("options", {}).get("--conf", {}).update(driverOptions)
 
+        project = payload.get('projectId', None)
+        if project:
+            projectOptions = {"spark.kubernetes.driverEnv.CORTEX_PROJECT": project,
+                             "spark.cortex.phoenix.project": project}
+            spark_config.get("pyspark", {}).get("options", {}).get("--conf", {}).update(projectOptions)
+
         # create spark-submit call
         run_args = get_runtime_args(spark_config, token, payload.get('apiEndpoint'))
 


### PR DESCRIPTION
Include project in passed down info to the spark driver. This is in two places now, as an env var: CORTEX_PROJECT and as a spark property: spark.cortex.phoenix.project